### PR TITLE
Update action section for consistency

### DIFF
--- a/src/1.0/actions.md
+++ b/src/1.0/actions.md
@@ -78,7 +78,7 @@ class UserResource < Avo::BaseResource
   field :id, as: :id
   # other fields
 
-  action ToggleInactive
+  action ToggleActive
 end
 ```
 

--- a/src/1.0/actions.md
+++ b/src/1.0/actions.md
@@ -10,6 +10,8 @@ Once you attach an action to a resource using the `actions` method it will appea
 
 ## Overview
 
+You generate one running `bin/rails generate avo:action toggle_active` creating an action configuration file.
+
 Avo actions use two main methods. `handle` and `fields`.
 
 ```ruby{4-18,20-23}


### PR DESCRIPTION
Issue#
------
During setting up Avo on a personal app, and viewing the docs on Actions I found there was no example of how to generate an action configuration file. This was a surprise as there were examples on the Filters page.

Also while reading the Actions page, I noticed that the class used to demonstrate registering an example,`ToggleInactive`, was not the expected one, and had no previous mention on the page.

Description:
------
This PR aims to reduce the readers confusion by updating the Action page.
- Adds example of the command to generate an action configuration file.
- Updates the name of the action class used in the registration example to the same one created in the previous example.