### PR TITLE
Directly access card options

### DIFF
--- a/src/2.0/dashboards.md
+++ b/src/2.0/dashboards.md
@@ -150,7 +150,7 @@ class UsersCount < Avo::Dashboards::MetricCard
   def query
     scope = User
 
-    if card.options[:active_users].present?
+    if options[:active_users].present?
       scope = scope.active
     end
 


### PR DESCRIPTION
Resolves:

```
ActionView::Template::Error (undefined local variable or method `card' for #<ContentCreatedChart:0x0000000112a5be60 @dashboard=BoardNumbers, @options={}, @index=1, @cols=3, @rows=1, @label=nil, @refresh_every=nil, @description=nil, @params=#<ActionController::Parameters {"turbo_frame"=>"board_numbers_content_created_chart", "index"=>"1", "range"=>"180", "controller"=>"avo/dashboards", "action"=>"card", "dashboard_id"=>"board_numbers", "card_id"=>"content_created_chart"} permitted: false>>):
    1: <%= turbo_frame_wrap(params[:turbo_frame]) do %>
    2:   <%= render Avo::CardComponent.new card: @card %>
    3: <% end %>
```