### PR TITLE
proposed wording correction

### DIFF
--- a/src/2.0/evaluation-hosts.md
+++ b/src/2.0/evaluation-hosts.md
@@ -48,4 +48,4 @@ Different hosts have different pieces of state.
 
 ## `RecordHost`
 
-The `RecordHost` is inherited from `BaseHost` and has the `record` available. The `record` is the actual model class instantiated with the DB information (like doing `User.find 1`) in that context.
+The `RecordHost` inherits from `BaseHost` and has the `record` available. The `record` is the actual model class instantiated with the DB information (like doing `User.find 1`) in that context.


### PR DESCRIPTION
I _think_ this change is what was intended.  

"The RecordHost is inherited from BaseHost" would mean that `RecordHost` is itself an attribute of `BaseHost` that `BaseHost`'s subclasses inherit, perhaps something slightly like this:

```
SubHost < BaseHost
  def record_provider
    RecordHost
  end
end

SubHost < BaseHost
end

sub = SubHost.new
sub.record_provider # => RecordHost
```

But it seems very unlikely that that was intended.