### PR TITLE
fixing statement about created resource

### DIFF
--- a/src/2.0/resources.md
+++ b/src/2.0/resources.md
@@ -18,7 +18,7 @@ bin/rails generate avo:resource post
 
 This command will generate a resource file under your `app/avo/resources` directory. The `app/avo` directory will hold all of your Avo configuration files.
 
-Inside the creates resource file will look like so:
+The created resource file will have the following code:
 
 ```ruby
 class PostResource < Avo::BaseResource


### PR DESCRIPTION
I'm guessing that the "s" was just a typographical error, and that you meant "d", since they're next to each other on the keyboard but both would be accepted by a spell-check.  On the grammatical change, it's a bit more complicated.

As with all cases where I try to make a correction, _I might be mistaken_ in determining the original intent, but _if I correctly interpreted the intent_, then this is a better way to say what you meant.  (I mention this because there is always the risk when attempting to make a correction of appearing to presume to be correct.  I make no such presumption, so please let me know if my correction is based on incorrectly interpreting what you meant.)

Here are two other alternatives in case you prefer one of them, or in case they help explain what is and isn't conventional in English.

* Inside the created resource file will be the following code:
* The created resource file will look like so:

I think part of the difficulty is that we don't use references to locations the same way in English as they are used in Spanish or Portuguese (and I'm going to guess that your native language is either Spanish or another Latinate language).  

For example, it's very common for native speakers of Spanish or Portuguese to say things like  "here is beautiful", using "here" as the subject of the sentence.  But we don't do this.  We would say "It is beautiful here", making "it" the subject, and "here" simply gives the listener an idea of where that subject is.  I am not certain, but I think that the way something like "inside the resource" is used in both languages is basically parallel to the way "here" is used. 

I hope that's helpful!