### PR TITLE
Update faq.md

### DIFF
--- a/src/2.0/faq.md
+++ b/src/2.0/faq.md
@@ -25,7 +25,7 @@ field :partner_home, as: :text, as_html: true do |model, *args|
 end
 ```
 
-This will not work because Avo will execute that code inside itself, a Rails engine. So per the [Rails documentation](https://guides.rubyonrails.org/engines.html#routes) you have to preprend the helper with `main_app` for it to work. Rails need to know for which engine should it search the route. So the above query becomes this 👇
+This will not work because Avo will execute that code inside itself, a Rails engine. So per the [Rails documentation](https://guides.rubyonrails.org/engines.html#routes) you have to preprend the helper with `main_app` for it to work. Rails needs to know which engine  it should find a route for. So the above query becomes this 👇
 
 
 ```ruby{2}
@@ -64,7 +64,7 @@ Avo.configure do |config|
 end
 ```
 
-## I want to have 2 different resources maped to the same model with different type
+## I want to have 2 different resources mapped to the same model with different types
 
 This depends on your setup:
 


### PR DESCRIPTION
There are a few changes here. 

A grammar checker might have told you to write "Rails need" because it mistakenly thought of "Rails" as a plural noun, but in the case of Ruby on Rails, it's a singular noun.  For example these 2 sentences are both correct, but use the word "Rails" differently:

* Rails _are_ used in making railroads and roller coasters.
* Rails _is_ an awesome web-development framework written in Ruby.

In the rest of the sentence I tried to rewrite it in the most natural English possible, which meant putting a preposition at the end.  (Many English teachers make the claim that doing so is bad grammar, and I would be happy to explain why I believe they are badly mistaken, but it's a big topic so I won't do that unless you want to hear more about that topic.)