### PR TITLE
Documentation for `Time` field

### DIFF
--- a/src/2.0/fields.md
+++ b/src/2.0/fields.md
@@ -120,7 +120,18 @@ By default, flatpickr is [disabled on mobile](https://flatpickr.js.org/mobile-su
 The `DateTime` field is similar to the Date field with two new attributes. `time_24hr` tells flatpickr to use 24 hours format and `timezone` to tell it in what timezone to display the time. By default it uses your browser's timezone.
 
 ```ruby
-filed :created_at, as: :date_time, name: 'User joined', picker_format: 'Y-m-d H:i', format: :db, time_24hr: true, timezone: 'PST'
+field :created_at, as: :date_time, name: 'User joined', picker_format: 'Y-m-d H:i', format: :db, time_24hr: true, timezone: 'PST'
+```
+
+## Time
+
+<!-- Replace this image with one of the Time field -->
+<img :src="$withBase('/assets/img/fields/date-time.jpg')" alt="DateTime field" class="border mb-4" />
+
+The `Time` field is similar to the DateTime field and uses the time picker of flatpickr (without the calendar). `time_24hr` tells flatpickr to use 24 hours format. Unlike in the `DateTime` field, the time always stays the same and doesn't change depending on your browser's timezone.
+
+```ruby
+field :starting_at, as: :time, picker_format: 'H:i', format: "HH:mm", time_24hr: true
 ```
 
 ## External image


### PR DESCRIPTION
I added some documentation for the new `Time` field I created in this PR avo-hq/avo#1311.

I am not sure how to create a new image which could be added here. I was thinking of something like this but maybe you could help me generate this to be consistent with the other images?
<img width="837" alt="Screenshot 2022-10-12 at 09 19 37" src="https://user-images.githubusercontent.com/28513469/195331781-f6a81a33-7eb1-4686-bf85-5dbcce3e6c06.png">

I also noticed a tiny typo in the word `field` in the DateTime field part so I also fixed this in here 👍 

Please let me know what you think :) 